### PR TITLE
Add automated trade analysis report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+reports/


### PR DESCRIPTION
## Summary
- save generated charts to disk and build an HTML trade analysis report that embeds them with summary statistics
- automatically fall back to bundled sample data when GUI selection is unavailable so a sample report is produced on run
- ignore timestamped report directories in version control

## Testing
- python trade_analysis_script.py

------
https://chatgpt.com/codex/tasks/task_e_68e46a002808832c90b31b61f3290887