### PR TITLE
Fix NameError when generating report without trade highlights

### DIFF
--- a/trade_analysis_script.py
+++ b/trade_analysis_script.py
@@ -473,7 +473,8 @@ def generate_report(
     graph_paths,
     pnl_analysis_table,
     day_hour_summary_html,
-    daily_net_pnl_html
+    daily_net_pnl_html,
+    trade_highlights_html=None
 ):
     report_dir.mkdir(parents=True, exist_ok=True)
     report_path = report_dir / 'trade_analysis_report.html'
@@ -845,7 +846,8 @@ def main():
             ],
             pnl_analysis_table,
             day_hour_summary_html,
-            daily_net_pnl_html
+            daily_net_pnl_html,
+            trade_highlights_html
         )
 
         print(f"Report generated at {report_path}")


### PR DESCRIPTION
## Summary
- allow `generate_report` to accept an optional `trade_highlights_html` argument
- pass the trade highlights HTML collected in `main` through to the report generator to avoid a NameError

## Testing
- python -m compileall trade_analysis_script.py

------
https://chatgpt.com/codex/tasks/task_e_68e4789071a0832ca341556df9aedb36