### PR TITLE
Fix graph card headings in report output

### DIFF
--- a/trade_analysis_script.py
+++ b/trade_analysis_script.py
@@ -484,7 +484,7 @@ def generate_report(
         if path is not None:
             graph_cards.append(
                 (
-                    "<div class='card graph-card'><h3>{title}</h3>"
+                    f"<div class='card graph-card'><h3>{title}</h3>"
                     f"<a href='{path.name}' target='_blank' class='graph-link'>"
                     f"<img src='{path.name}' alt='{title}' loading='lazy'></a></div>"
                 )


### PR DESCRIPTION
## Summary
- render the graph card heading markup in generate_report using an f-string so chart titles appear
- regenerate the sample report to verify the card headings include the expected titles

## Testing
- python trade_analysis_script.py

------
https://chatgpt.com/codex/tasks/task_e_68e47a9b7524832ca92b34d1120c7e2b