### PR TITLE
Wrap trade highlights table in scroll container

### DIFF
--- a/trade_analysis_script.py
+++ b/trade_analysis_script.py
@@ -531,7 +531,9 @@ def generate_report(
             <section>
                 <h2>Trade-Level Highlights</h2>
                 <div class='card'>
-                    {trade_highlights_html}
+                    <div class='table-scroll'>
+                        {trade_highlights_html}
+                    </div>
                 </div>
             </section>
         """
@@ -648,12 +650,15 @@ def generate_report(
                 transition: transform 0.2s ease;
                 image-rendering: optimizeQuality;
             }}
+            .table-scroll {{
+                width: 100%;
+                overflow-x: auto;
+            }}
             .styled-table {{
                 width: 100%;
                 border-collapse: collapse;
                 margin-top: 1rem;
                 font-size: 0.95rem;
-                overflow: hidden;
                 border-radius: 0.85rem;
                 box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
             }}


### PR DESCRIPTION
## Summary
- add a reusable `.table-scroll` helper with horizontal overflow support for data tables
- wrap the trade highlights table in the responsive container and remove the restrictive overflow rule on styled tables

## Testing
- python trade_analysis_script.py

------
https://chatgpt.com/codex/tasks/task_e_68e47a9e61b8832ca8c36c618a248a3b