### PR TITLE
Fix NaT adjustment per symbol and add regression test

### DIFF
--- a/tests/test_adjust_nat_times.py
+++ b/tests/test_adjust_nat_times.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytz
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from trade_analysis_script import adjust_nat_times
+
+
+def test_adjust_nat_times_uses_matching_symbol_fallbacks():
+    tz = pytz.timezone('US/Eastern')
+
+    data = {
+        'Symbol': ['ES', 'NQ', 'ES', 'CL', 'NQ', 'ES', 'CL'],
+        'OpenClose': ['open', 'open', 'close', 'close', 'close', 'close', 'close'],
+        'TransDateTime': [
+            pd.Timestamp('2024-01-01 09:00', tz=tz),
+            pd.Timestamp('2024-01-01 09:02', tz=tz),
+            pd.NaT,
+            pd.NaT,
+            pd.NaT,
+            pd.Timestamp('2024-01-01 09:10', tz=tz),
+            pd.Timestamp('2024-01-01 09:20', tz=tz),
+        ],
+    }
+
+    df = pd.DataFrame(data)
+
+    adjusted_df = adjust_nat_times(df.copy())
+
+    expected_es_close = pd.Timestamp('2024-01-01 09:01', tz=tz)
+    expected_nq_close = pd.Timestamp('2024-01-01 09:03', tz=tz)
+    expected_cl_close = pd.Timestamp('2024-01-01 09:19', tz=tz)
+
+    assert adjusted_df.loc[2, 'TransDateTime'] == expected_es_close
+    assert adjusted_df.loc[4, 'TransDateTime'] == expected_nq_close
+    assert adjusted_df.loc[3, 'TransDateTime'] == expected_cl_close
+
+    # Ensure existing timestamps remain unchanged
+    assert adjusted_df.loc[5, 'TransDateTime'] == df.loc[5, 'TransDateTime']
+    assert adjusted_df.loc[6, 'TransDateTime'] == df.loc[6, 'TransDateTime']

--- a/trade_analysis_script.py
+++ b/trade_analysis_script.py
@@ -96,22 +96,42 @@ def adjust_nat_times(df):
     :param df: DataFrame with the trade data.
     :return: DataFrame with adjusted 'TransDateTime' for NaT values.
     """
-    open_indices = df[df['OpenClose'] == 'open'].index
+    open_indices_by_symbol = {
+        symbol: group.index
+        for symbol, group in df[df['OpenClose'] == 'open'].groupby('Symbol')
+    }
     close_indices = df[df['OpenClose'] == 'close'].index
+    close_indices_by_symbol = {
+        symbol: group.index
+        for symbol, group in df[df['OpenClose'] == 'close'].groupby('Symbol')
+    }
 
     # Loop through close indices to adjust NaT values based on the open time or the next close time
     for close_index in close_indices:
         if pd.isna(df.at[close_index, 'TransDateTime']):
-            # Find the preceding open trade's index for the current close trade
-            preceding_open_index = open_indices[open_indices < close_index].max()
-            # If there's a valid open trade before this close trade, add 1 minute to its time
-            if pd.notna(preceding_open_index):
-                df.at[close_index, 'TransDateTime'] = df.at[preceding_open_index, 'TransDateTime'] + Minute(1)
-            else:
-                # If there's no valid open trade before, try to subtract 1 minute from the next valid close time
-                following_close_index = close_indices[close_indices > close_index].min()
-                if pd.notna(following_close_index):
-                    df.at[close_index, 'TransDateTime'] = df.at[following_close_index, 'TransDateTime'] - Minute(1)
+            symbol = df.at[close_index, 'Symbol']
+
+            preceding_open_index = None
+            if symbol in open_indices_by_symbol:
+                symbol_open_indices = open_indices_by_symbol[symbol]
+                preceding_open_candidates = symbol_open_indices[symbol_open_indices < close_index]
+                if len(preceding_open_candidates) > 0:
+                    preceding_open_index = preceding_open_candidates.max()
+
+            if preceding_open_index is not None:
+                open_time = df.at[preceding_open_index, 'TransDateTime']
+                if pd.notna(open_time):
+                    df.at[close_index, 'TransDateTime'] = open_time + Minute(1)
+                    continue
+
+            if symbol in close_indices_by_symbol:
+                symbol_close_indices = close_indices_by_symbol[symbol]
+                following_close_candidates = symbol_close_indices[symbol_close_indices > close_index]
+                for following_close_index in following_close_candidates:
+                    following_time = df.at[following_close_index, 'TransDateTime']
+                    if pd.notna(following_time):
+                        df.at[close_index, 'TransDateTime'] = following_time - Minute(1)
+                        break
 
     return df
 


### PR DESCRIPTION
## Summary
- ensure adjust_nat_times only pulls fallback timestamps from matching symbol opens and closes
- add regression test covering interleaved symbols with NaT closes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4881eb03c832c9be11836195ad681